### PR TITLE
use standard definition for iskeyword, as for other shells

### DIFF
--- a/ftplugin/fish.vim
+++ b/ftplugin/fish.vim
@@ -5,7 +5,6 @@ setlocal foldexpr=fish#Fold()
 setlocal formatoptions+=ron1
 setlocal formatoptions-=t
 setlocal include=\\v^\\s*\\.>
-setlocal iskeyword=@,48-57,-,_,.,/
 setlocal suffixesadd^=.fish
 
 " Use the 'j' format option when available.


### PR DESCRIPTION
This effectively removes "-", "." and "/" from the set of word characters.

Prior to this, a `w` would skip over the entirety of /some/long/path-name. This
is probably not what users expect, since they can use `W` for that.

----

This is just a copy of [this PR](https://github.com/dag/vim-fish/pull/44) by @krobelus which was opened against [the upstream repository](https://github.com/dag/vim-fish) before this fork was created. I ran into the same issue recently and seeing how this fork is being used by [vim-polyglot](https://github.com/sheerun/vim-polyglot), I figured I'd try to get it merged here.